### PR TITLE
Add Google Analytics

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -37,7 +37,7 @@
       |
       =link_to "Sobre o Dengue Torpedo", about_path
     %span
-      2012 © Regents of the University of California
+      2014 © Regents of the University of California
       |
       =link_to "Criado pelo Social Apps Lab, UC Berkeley", credit_path
   = yield :scripts


### PR DESCRIPTION
Let's use GA to track how people use the site but, most importantly, what browsers they use. This will allow us to make decisions about IE8 and IE9.
