### PR TITLE
Backfill all locations with Mare neighborhood

### DIFF
--- a/lib/tasks/locations.rake
+++ b/lib/tasks/locations.rake
@@ -1,0 +1,18 @@
+# encoding: UTF-8
+
+#------
+# NOTE: This is a one-time rake task that will populate
+# all existing locations with the Mare neighborhood.
+# DO NOT run this without permission from @dman7.
+
+namespace :locations do
+  desc "[One-off backfill task] Backfill locations with Maré neighborhood"
+  task :backfill_locations_with_mare_neighborhood => :environment do
+    mare_neighborhood = Neighborhood.first
+
+    Location.find_each do |loc|
+      next if loc.neighborhood_id.present?
+      loc.update_attribute(:neighborhood_id, mare_neighborhood.id)
+    end
+  end
+end


### PR DESCRIPTION
For some odd reason, the total number of reports does not match number of reports in the neighborhood Mare:

```
[Production data]
irb(main):001:0> Neighborhood.first.reports.count
  Neighborhood Load (114.8ms)  SELECT "neighborhoods".* FROM "neighborhoods" LIMIT 1
   (26.6ms)  SELECT COUNT(*) FROM "reports" INNER JOIN "locations" ON "reports"."location_id" = "locations"."id" WHERE "locations"."neighborhood_id" = 1
=> 1
irb(main):002:0> Report.all.count
  Report Load (2.9ms)  SELECT "reports".* FROM "reports" 
=> 51
irb(main):004:0> 
```

Since up to this point, the only users using the site were from Mare, let's go ahead and backfill all `locations` instances with the neighborhood of Mare.
