### PR TITLE
Bug: Adminstrar DT Torpedos

### DIFF
--- a/app/views/users/phones.html.haml
+++ b/app/views/users/phones.html.haml
@@ -17,12 +17,12 @@
 			%th Pré/Pós
 			%th DT Torpedos total
 			%th DT Torpedos a creditar
-			%th 
+			%th
 				%i SMS req.
 		- @users.each do |user|
 			%tr
 				%td{style: "text-align:left"}= link_to user.display_name, "torpedos/#{user.id}"
-				%td= user.phone_number.sub(/^0/, "")
+				%td= user.phone_number.sub(/^0/, "") if user.phone_number
 				%td= user.carrier
 				- if user.prepaid == true
 					%td Pré


### PR DESCRIPTION
```
2014-03-14T19:01:27.534404+00:00 app[web.1]: Started GET "/phones" for 24.130.84.180 at 2014-03-14 19:01:27 +0000
2014-03-14T19:01:27.624747+00:00 app[web.1]: 
2014-03-14T19:01:27.624747+00:00 app[web.1]: ActionView::Template::Error (undefined method `sub' for nil:NilClass):
2014-03-14T19:01:27.624747+00:00 app[web.1]:     22:        - @users.each do |user|
2014-03-14T19:01:27.624747+00:00 app[web.1]:     23:            %tr
2014-03-14T19:01:27.624747+00:00 app[web.1]:     24:                %td{style: "text-align:left"}= link_to user.display_name, "torpedos/#{user.id}"
2014-03-14T19:01:27.624747+00:00 app[web.1]:     25:                %td= user.phone_number.sub(/^0/, "")
2014-03-14T19:01:27.624747+00:00 app[web.1]:     26:                %td= user.carrier
2014-03-14T19:01:27.624747+00:00 app[web.1]:     27:                - if user.prepaid == true
2014-03-14T19:01:27.632539+00:00 heroku[router]: at=info method=GET path=/phones host=www.denguetorpedo.com request_id=584a0c1d-73ce-4d89-a935-c7e5e36174d2 fwd="24.130.84.180" dyno=web.1 connect=13ms service=99ms status=500 bytes=931
2014-03-14T19:01:27.624747+00:00 app[web.1]:     28:                    %td Pré
2014-03-14T19:01:27.624747+00:00 app[web.1]:   app/views/users/phones.html.haml:25:in `block in _app_views_users_phones_html_haml__277275714541737167_61805000'
2014-03-14T19:01:27.624983+00:00 app[web.1]:   app/views/users/phones.html.haml:22:in `_app_views_users_phones_html_haml__277275714541737167_61805000'
2014-03-14T19:01:27.624983+00:00 app[web.1]: 
2014-03-14T19:01:27.624983+00:00 app[web.1]: 
```
