### PR TITLE
Change derailed_benchmarks dependency to https

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem "yuicompressor"
 #------------------------------------------------------------------------------
 
 group :development do
-  gem 'derailed_benchmarks', :git => "git@github.com:schneems/derailed_benchmarks.git", :require => false
+  gem 'derailed_benchmarks', :git => "https://github.com/schneems/derailed_benchmarks.git", :require => false
   gem 'rack-mini-profiler', :require => false
   gem 'web-console', '~> 2.0'
 end


### PR DESCRIPTION
Change the repo of the derailed_benchmarks dependency to https to avoid have a ssh key configured.