### PR TITLE
Added organization_id when creating a team

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -65,7 +65,8 @@ class TeamsController < ApplicationController
   def create
     @team                 = Team.new(params[:team])
     @team.neighborhood_id = @neighborhood.id
-
+    @team.organization_id = current_user.selected_membership.organization_id
+    
     base64_image = params[:team][:compressed_photo]
     if base64_image.present?
       filename            = "team_profile_photo.jpg"


### PR DESCRIPTION
The absence of it caused an error while getting the list of teams, they depends on an organization, and since there was no organization_id on their records, the response payload was empty

Signed-off-by: ricpar11 <ricpar11@gmail.com>